### PR TITLE
#1 Support multiple Markdown and Code Example directories

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -5,11 +5,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/swaggo/swag"
 	"github.com/swaggo/swag/format"
 	"github.com/swaggo/swag/gen"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -67,17 +66,17 @@ var initFlags = []cli.Flag{
 		Aliases: []string{"pd"},
 		Usage:   "Parse go files inside dependency folder, disabled by default",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		Name:    markdownFilesFlag,
 		Aliases: []string{"md"},
-		Value:   "",
-		Usage:   "Parse folder containing markdown files to use as description, disabled by default",
+		Value:   nil,
+		Usage:   "Parse folders containing markdown files to use as description, disabled by default",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		Name:    codeExampleFilesFlag,
 		Aliases: []string{"cef"},
-		Value:   "",
-		Usage:   "Parse folder containing code example files to use for the x-codeSamples extension, disabled by default",
+		Value:   nil,
+		Usage:   "Parse folders containing code example files to use for the x-codeSamples extension, disabled by default",
 	},
 	&cli.BoolFlag{
 		Name:  parseInternalFlag,
@@ -114,20 +113,20 @@ func initAction(c *cli.Context) error {
 	}
 
 	return gen.New().Build(&gen.Config{
-		SearchDir:           c.String(searchDirFlag),
-		Excludes:            c.String(excludeFlag),
-		MainAPIFile:         c.String(generalInfoFlag),
-		PropNamingStrategy:  strategy,
-		OutputDir:           c.String(outputFlag),
-		ParseVendor:         c.Bool(parseVendorFlag),
-		ParseDependency:     c.Bool(parseDependencyFlag),
-		MarkdownFilesDir:    c.String(markdownFilesFlag),
-		ParseInternal:       c.Bool(parseInternalFlag),
-		GeneratedTime:       c.Bool(generatedTimeFlag),
-		CodeExampleFilesDir: c.String(codeExampleFilesFlag),
-		ParseDepth:          c.Int(parseDepthFlag),
-		InstanceName:        c.String(instanceNameFlag),
-		OverridesFile:       c.String(overridesFileFlag),
+		SearchDir:            c.String(searchDirFlag),
+		Excludes:             c.String(excludeFlag),
+		MainAPIFile:          c.String(generalInfoFlag),
+		PropNamingStrategy:   strategy,
+		OutputDir:            c.String(outputFlag),
+		ParseVendor:          c.Bool(parseVendorFlag),
+		ParseDependency:      c.Bool(parseDependencyFlag),
+		MarkdownFilesDirs:    c.StringSlice(markdownFilesFlag),
+		ParseInternal:        c.Bool(parseInternalFlag),
+		GeneratedTime:        c.Bool(generatedTimeFlag),
+		CodeExampleFilesDirs: c.StringSlice(codeExampleFilesFlag),
+		ParseDepth:           c.Int(parseDepthFlag),
+		InstanceName:         c.String(instanceNameFlag),
+		OverridesFile:        c.String(overridesFileFlag),
 	})
 }
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -57,11 +57,11 @@ type Config struct {
 	// PropNamingStrategy represents property naming strategy like snake case,camel case,pascal case
 	PropNamingStrategy string
 
-	// MarkdownFilesDir used to find markdown files, which can be used for tag descriptions
-	MarkdownFilesDir string
+	// MarkdownFilesDirs used to find markdown files, which can be used for tag descriptions
+	MarkdownFilesDirs []string
 
-	// CodeExampleFilesDir used to find code example files, which can be used for x-codeSamples
-	CodeExampleFilesDir string
+	// CodeExampleFilesDirs used to find code example files, which can be used for x-codeSamples
+	CodeExampleFilesDirs []string
 
 	// InstanceName is used to get distinct names for different swagger documents in the
 	// same project. The default value is "swagger".
@@ -121,9 +121,9 @@ func (g *Gen) Build(config *Config) error {
 	}
 
 	log.Println("Generate swagger docs....")
-	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
+	p := swag.New(swag.SetMarkdownFileDirectories(config.MarkdownFilesDirs...),
 		swag.SetExcludedDirsAndFiles(config.Excludes),
-		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir),
+		swag.SetCodeExamplesDirectories(config.CodeExampleFilesDirs...),
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),
 	)

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -135,10 +135,10 @@ func TestGen_BuildLowerCamelcase(t *testing.T) {
 
 func TestGen_BuildDescriptionWithQuotes(t *testing.T) {
 	config := &Config{
-		SearchDir:        "../testdata/quotes",
-		MainAPIFile:      "./main.go",
-		OutputDir:        "../testdata/quotes/docs",
-		MarkdownFilesDir: "../testdata/quotes",
+		SearchDir:         "../testdata/quotes",
+		MainAPIFile:       "./main.go",
+		OutputDir:         "../testdata/quotes/docs",
+		MarkdownFilesDirs: []string{"../testdata/quotes"},
 	}
 
 	require.NoError(t, New().Build(config))

--- a/operation.go
+++ b/operation.go
@@ -27,8 +27,8 @@ type RouteProperties struct {
 // Operation describes a single API operation on a path.
 // For more information: https://github.com/swaggo/swag#api-operation
 type Operation struct {
-	parser              *Parser
-	codeExampleFilesDir string
+	parser               *Parser
+	codeExampleFilesDirs []string
 	spec.Operation
 	RouterProperties []RouteProperties
 }
@@ -81,10 +81,10 @@ func NewOperation(parser *Parser, options ...func(*Operation)) *Operation {
 	return result
 }
 
-// SetCodeExampleFilesDirectory sets the directory to search for codeExamples.
-func SetCodeExampleFilesDirectory(directoryPath string) func(*Operation) {
+// SetCodeExampleFilesDirectories sets the directories to search for codeExamples.
+func SetCodeExampleFilesDirectories(directoryPaths ...string) func(*Operation) {
 	return func(o *Operation) {
-		o.codeExampleFilesDir = directoryPath
+		o.codeExampleFilesDirs = directoryPaths
 	}
 }
 
@@ -103,7 +103,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	case descriptionAttr:
 		operation.ParseDescriptionComment(lineRemainder)
 	case descriptionMarkdownAttr:
-		commentInfo, err := getMarkdownForTag(lineRemainder, operation.parser.markdownFileDir)
+		commentInfo, err := getMarkdownForTag(lineRemainder, operation.parser.markdownFileDirs)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 // ParseCodeSample godoc.
 func (operation *Operation) ParseCodeSample(attribute, _, lineRemainder string) error {
 	if lineRemainder == "file" {
-		data, err := getCodeExampleForSummary(operation.Summary, operation.codeExampleFilesDir)
+		data, err := getCodeExampleForSummary(operation.Summary, operation.codeExampleFilesDirs)
 		if err != nil {
 			return err
 		}
@@ -1031,30 +1031,33 @@ func createParameter(paramType, description, paramName, schemaType string, requi
 	return result
 }
 
-func getCodeExampleForSummary(summaryName string, dirPath string) ([]byte, error) {
-	filesInfos, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return nil, err
-	}
+func getCodeExampleForSummary(summaryName string, dirPaths []string) ([]byte, error) {
+	for _, dirPath := range dirPaths {
 
-	for _, fileInfo := range filesInfos {
-		if fileInfo.IsDir() {
-			continue
-		}
-		fileName := fileInfo.Name()
-
-		if !strings.Contains(fileName, ".json") {
-			continue
+		filesInfos, err := ioutil.ReadDir(dirPath)
+		if err != nil {
+			return nil, err
 		}
 
-		if strings.Contains(fileName, summaryName) {
-			fullPath := filepath.Join(dirPath, fileName)
-			commentInfo, err := ioutil.ReadFile(fullPath)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to read code example file %s error: %s ", fullPath, err)
+		for _, fileInfo := range filesInfos {
+			if fileInfo.IsDir() {
+				continue
+			}
+			fileName := fileInfo.Name()
+
+			if !strings.Contains(fileName, ".json") {
+				continue
 			}
 
-			return commentInfo, nil
+			if strings.Contains(fileName, summaryName) {
+				fullPath := filepath.Join(dirPath, fileName)
+				commentInfo, err := ioutil.ReadFile(fullPath)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to read code example file %s error: %s ", fullPath, err)
+				}
+
+				return commentInfo, nil
+			}
 		}
 	}
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -2002,7 +2002,7 @@ func TestParseDescriptionMarkdown(t *testing.T) {
 	t.Parallel()
 
 	operation := NewOperation(nil)
-	operation.parser.markdownFileDir = "example/markdown"
+	operation.parser.markdownFileDirs = []string{"example/markdown"}
 
 	comment := `@description.markdown admin.md`
 
@@ -2191,7 +2191,7 @@ func TestParseCodeSamples(t *testing.T) {
 	const comment = `@x-codeSamples file`
 	t.Run("Find sample by file", func(t *testing.T) {
 
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "example"
 
 		err := operation.ParseComment(comment, nil)
@@ -2202,7 +2202,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run("With broken file sample", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "broken"
 
 		err := operation.ParseComment(comment, nil)
@@ -2210,7 +2210,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run("Example file not found", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "badExample"
 
 		err := operation.ParseComment(comment, nil)
@@ -2219,7 +2219,7 @@ func TestParseCodeSamples(t *testing.T) {
 
 	t.Run("Without line reminder", func(t *testing.T) {
 		comment := `@x-codeSamples`
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "example"
 
 		err := operation.ParseComment(comment, nil)
@@ -2227,7 +2227,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run(" broken dir", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/fake_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/fake_examples"))
 		operation.Summary = "code"
 
 		err := operation.ParseComment(comment, nil)

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,16 +24,16 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		expected := "docs/markdown"
-		p := New(SetMarkdownFileDirectory(expected))
-		assert.Equal(t, expected, p.markdownFileDir)
+		p := New(SetMarkdownFileDirectories(expected))
+		assert.Equal(t, expected, p.markdownFileDirs)
 	})
 
 	t.Run("SetCodeExamplesDirectory", func(t *testing.T) {
 		t.Parallel()
 
 		expected := "docs/examples"
-		p := New(SetCodeExamplesDirectory(expected))
-		assert.Equal(t, expected, p.codeExampleFilesDir)
+		p := New(SetCodeExamplesDirectories(expected))
+		assert.Equal(t, expected, p.codeExampleFilesDirs)
 	})
 
 	t.Run("SetStrict", func(t *testing.T) {
@@ -358,7 +358,7 @@ func TestParser_ParseGeneralApiInfoWithOpsInSameFile(t *testing.T) {
 func TestParser_ParseGeneralAPIInfoMarkdown(t *testing.T) {
 	t.Parallel()
 
-	p := New(SetMarkdownFileDirectory("testdata"))
+	p := New(SetMarkdownFileDirectories("testdata"))
 	mainAPIFile := "testdata/markdown.go"
 	err := p.ParseGeneralAPIInfo(mainAPIFile)
 	assert.NoError(t, err)
@@ -2769,7 +2769,7 @@ func TestApiParseTag(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
@@ -2799,7 +2799,7 @@ func TestApiParseTag_NonExistendTag(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags_nonexistend_tag"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.Error(t, err)
@@ -2809,7 +2809,7 @@ func TestParseTagMarkdownDescription(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	if err != nil {
@@ -2830,7 +2830,7 @@ func TestParseApiMarkdownDescription(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	if err != nil {


### PR DESCRIPTION
You can call "--md" and "--cef" multiple times, and swag will look for the right files in all of the directories.