### PR TITLE
Support multiple Markdown and Code Example directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,15 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.15.x', '1.16.x', '1.17.x' ]
+        go: ["1.15.x", "1.16.x", "1.17.x"]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -23,15 +23,15 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: deps
         working-directory: ./src/github.com/${{ github.repository }}
-        run:  make deps
+        run: make deps
         env:
           GOPATH: ${{ runner.workspace }}
       - name: static program analysis
         working-directory: ./src/github.com/${{ github.repository }}
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin # https://github.com/actions/setup-go/issues/14
-          mkdir -p $(go env GOPATH)/src/github.com/swaggo
-          ln -s $(pwd) $(go env GOPATH)/src/github.com/swaggo/swag
+          mkdir -p $(go env GOPATH)/src/github.com/piiano
+          ln -s $(pwd) $(go env GOPATH)/src/github.com/piiano/swag
           make fmt-check lint vet
         env:
           GOPATH: ${{ runner.workspace }}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOPATH:=$(shell $(GOCMD) env GOPATH)
 u := $(if $(update),-u)
 
 BINARY_NAME:=swag
-PACKAGES:=$(shell $(GOLIST) github.com/swaggo/swag github.com/swaggo/swag/cmd/swag github.com/swaggo/swag/gen)
+PACKAGES:=$(shell $(GOLIST) github.com/piiano/swag github.com/piiano/swag/cmd/swag github.com/piiano/swag/gen)
 GOFILES:=$(shell find . -name "*.go" -type f)
 
 export GO111MODULE := on

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 e.g. add cool parser.
 
 **Relation issue**
-e.g. https://github.com/swaggo/swag/pull/118/files
+e.g. https://github.com/piiano/swag/pull/118/files
 
 **Additional context**
 Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 <img align="right" width="180px" src="https://raw.githubusercontent.com/swaggo/swag/master/assets/swaggo.png">
 
-[![Build Status](https://github.com/swaggo/swag/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/features/actions)
+[![Build Status](https://github.com/piiano/swag/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/features/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/github/swaggo/swag/master.svg)](https://codecov.io/gh/swaggo/swag)
-[![Go Report Card](https://goreportcard.com/badge/github.com/swaggo/swag)](https://goreportcard.com/report/github.com/swaggo/swag)
+[![Go Report Card](https://goreportcard.com/badge/github.com/piiano/swag)](https://goreportcard.com/report/github.com/piiano/swag)
 [![codebeat badge](https://codebeat.co/badges/71e2f5e5-9e6b-405d-baf9-7cc8b5037330)](https://codebeat.co/projects/github-com-swaggo-swag-master)
-[![Go Doc](https://godoc.org/github.com/swaggo/swagg?status.svg)](https://godoc.org/github.com/swaggo/swag)
+[![Go Doc](https://godoc.org/github.com/piiano/swagg?status.svg)](https://godoc.org/github.com/piiano/swag)
 [![Backers on Open Collective](https://opencollective.com/swag/backers/badge.svg)](#backers) 
 [![Sponsors on Open Collective](https://opencollective.com/swag/sponsors/badge.svg)](#sponsors) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fswaggo%2Fswag.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fswaggo%2Fswag?ref=badge_shield)
-[![Release](https://img.shields.io/github/release/swaggo/swag.svg?style=flat-square)](https://github.com/swaggo/swag/releases)
+[![Release](https://img.shields.io/github/release/swaggo/swag.svg?style=flat-square)](https://github.com/piiano/swag/releases)
 
 
 Swag converts Go annotations to Swagger Documentation 2.0. We've created a variety of plugins for popular [Go web frameworks](#supported-web-frameworks). This allows you to quickly integrate with an existing Go project (using Swagger UI).
@@ -50,14 +50,14 @@ Swag converts Go annotations to Swagger Documentation 2.0. We've created a varie
 
 2. Download swag by using:
 ```sh
-$ go get -u github.com/swaggo/swag/cmd/swag
+$ go get -u github.com/piiano/swag/cmd/swag
 
 # 1.16 or newer
-$ go install github.com/swaggo/swag/cmd/swag@latest
+$ go install github.com/piiano/swag/cmd/swag@latest
 ```
 To build from source you need [Go](https://golang.org/dl/) (1.15 or newer).
 
-Or download a pre-compiled binary from the [release page](https://github.com/swaggo/swag/releases).
+Or download a pre-compiled binary from the [release page](https://github.com/piiano/swag/releases).
 
 3. Run `swag init` in the project's root folder which contains the `main.go` file. This will parse your comments and generate the required files (`docs` folder and `docs/docs.go`).
 ```sh
@@ -132,7 +132,7 @@ OPTIONS:
 
 ## How to use it with Gin
 
-Find the example source code [here](https://github.com/swaggo/swag/tree/master/example/celler).
+Find the example source code [here](https://github.com/piiano/swag/tree/master/example/celler).
 
 1. After using `swag init` to generate Swagger 2.0 docs, import the following packages:
 ```go
@@ -232,8 +232,8 @@ import (
     "strconv"
 
     "github.com/gin-gonic/gin"
-    "github.com/swaggo/swag/example/celler/httputil"
-    "github.com/swaggo/swag/example/celler/model"
+    "github.com/piiano/swag/example/celler/httputil"
+    "github.com/piiano/swag/example/celler/model"
 )
 
 // ShowAccount godoc
@@ -298,7 +298,7 @@ $ swag init
 ## The swag formatter
 
 The Swag Comments can be automatically formatted, just like 'go fmt'.  
-Find the result of formatting [here](https://github.com/swaggo/swag/tree/master/example/celler).
+Find the result of formatting [here](https://github.com/piiano/swag/tree/master/example/celler).
 
 Usage: 
 ```shell
@@ -335,69 +335,69 @@ swag fmt -d ./ --exclude ./internal
 ## General API Info
 
 **Example**
-[celler/main.go](https://github.com/swaggo/swag/blob/master/example/celler/main.go)
+[celler/main.go](https://github.com/piiano/swag/blob/master/example/celler/main.go)
 
-| annotation  | description                                | example                         |
-|-------------|--------------------------------------------|---------------------------------|
-| title       | **Required.** The title of the application.| // @title Swagger Example API   |
-| version     | **Required.** Provides the version of the application API.| // @version 1.0  |
-| description | A short description of the application.    |// @description This is a sample server celler server.         																 |
-| tag.name    | Name of a tag.| // @tag.name This is the name of the tag                     |
-| tag.description   | Description of the tag  | // @tag.description Cool Description         |
-| tag.docs.url      | Url of the external Documentation of the tag | // @tag.docs.url https://example.com|
-| tag.docs.description  | Description of the external Documentation of the tag| // @tag.docs.description Best example documentation |
-| termsOfService | The Terms of Service for the API.| // @termsOfService http://swagger.io/terms/                     |
-| contact.name | The contact information for the exposed API.| // @contact.name API Support  |
-| contact.url  | The URL pointing to the contact information. MUST be in the format of a URL.  | // @contact.url http://www.swagger.io/support|
-| contact.email| The email address of the contact person/organization. MUST be in the format of an email address.| // @contact.email support@swagger.io                                   |
-| license.name | **Required.** The license name used for the API.|// @license.name Apache 2.0|
-| license.url  | A URL to the license used for the API. MUST be in the format of a URL.                       | // @license.url http://www.apache.org/licenses/LICENSE-2.0.html |
-| host        | The host (name or ip) serving the API.     | // @host localhost:8080         |
-| BasePath    | The base path on which the API is served. | // @BasePath /api/v1             |
-| accept      | A list of MIME types the APIs can consume. Note that Accept only affects operations with a request body, such as POST, PUT and PATCH.  Value MUST be as described under [Mime Types](#mime-types).                     | // @accept json |
-| produce     | A list of MIME types the APIs can produce. Value MUST be as described under [Mime Types](#mime-types).                     | // @produce json |
-| query.collection.format | The default collection(array) param format in query,enums:csv,multi,pipes,tsv,ssv. If not set, csv is the default.| // @query.collection.format multi
-| schemes     | The transfer protocol for the operation that separated by spaces. | // @schemes http https |
-| x-name      | The extension key, must be start by x- and take only json value | // @x-example-key {"key": "value"} |
+| annotation              | description                                                                                                                                                                                        | example                                                         |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| title                   | **Required.** The title of the application.                                                                                                                                                        | // @title Swagger Example API                                   |
+| version                 | **Required.** Provides the version of the application API.                                                                                                                                         | // @version 1.0                                                 |
+| description             | A short description of the application.                                                                                                                                                            | // @description This is a sample server celler server.          |
+| tag.name                | Name of a tag.                                                                                                                                                                                     | // @tag.name This is the name of the tag                        |
+| tag.description         | Description of the tag                                                                                                                                                                             | // @tag.description Cool Description                            |
+| tag.docs.url            | Url of the external Documentation of the tag                                                                                                                                                       | // @tag.docs.url https://example.com                            |
+| tag.docs.description    | Description of the external Documentation of the tag                                                                                                                                               | // @tag.docs.description Best example documentation             |
+| termsOfService          | The Terms of Service for the API.                                                                                                                                                                  | // @termsOfService http://swagger.io/terms/                     |
+| contact.name            | The contact information for the exposed API.                                                                                                                                                       | // @contact.name API Support                                    |
+| contact.url             | The URL pointing to the contact information. MUST be in the format of a URL.                                                                                                                       | // @contact.url http://www.swagger.io/support                   |
+| contact.email           | The email address of the contact person/organization. MUST be in the format of an email address.                                                                                                   | // @contact.email support@swagger.io                            |
+| license.name            | **Required.** The license name used for the API.                                                                                                                                                   | // @license.name Apache 2.0                                     |
+| license.url             | A URL to the license used for the API. MUST be in the format of a URL.                                                                                                                             | // @license.url http://www.apache.org/licenses/LICENSE-2.0.html |
+| host                    | The host (name or ip) serving the API.                                                                                                                                                             | // @host localhost:8080                                         |
+| BasePath                | The base path on which the API is served.                                                                                                                                                          | // @BasePath /api/v1                                            |
+| accept                  | A list of MIME types the APIs can consume. Note that Accept only affects operations with a request body, such as POST, PUT and PATCH.  Value MUST be as described under [Mime Types](#mime-types). | // @accept json                                                 |
+| produce                 | A list of MIME types the APIs can produce. Value MUST be as described under [Mime Types](#mime-types).                                                                                             | // @produce json                                                |
+| query.collection.format | The default collection(array) param format in query,enums:csv,multi,pipes,tsv,ssv. If not set, csv is the default.                                                                                 | // @query.collection.format multi                               |
+| schemes                 | The transfer protocol for the operation that separated by spaces.                                                                                                                                  | // @schemes http https                                          |
+| x-name                  | The extension key, must be start by x- and take only json value                                                                                                                                    | // @x-example-key {"key": "value"}                              |
 
 ### Using markdown descriptions
 When a short string in your documentation is insufficient, or you need images, code examples and things like that you may want to use markdown descriptions. In order to use markdown descriptions use the following annotations.
 
 
-| annotation  | description                                | example                         |
-|-------------|--------------------------------------------|---------------------------------|
-| title       | **Required.** The title of the application.| // @title Swagger Example API   |
-| version     | **Required.** Provides the version of the application API.| // @version 1.0  |
-| description.markdown  | A short description of the application. Parsed from the api.md file. This is an alternative to @description    |// @description.markdown No value needed, this parses the description from api.md         																 |
-| tag.name    | Name of a tag.| // @tag.name This is the name of the tag                     |
-| tag.description.markdown   | Description of the tag this is an alternative to tag.description. The description will be read from a file named like tagname.md  | // @tag.description.markdown         |
+| annotation               | description                                                                                                                      | example                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| title                    | **Required.** The title of the application.                                                                                      | // @title Swagger Example API                                                     |
+| version                  | **Required.** Provides the version of the application API.                                                                       | // @version 1.0                                                                   |
+| description.markdown     | A short description of the application. Parsed from the api.md file. This is an alternative to @description                      | // @description.markdown No value needed, this parses the description from api.md |
+| tag.name                 | Name of a tag.                                                                                                                   | // @tag.name This is the name of the tag                                          |
+| tag.description.markdown | Description of the tag this is an alternative to tag.description. The description will be read from a file named like tagname.md | // @tag.description.markdown                                                      |
 
 
 ## API Operation
 
 **Example**
-[celler/controller](https://github.com/swaggo/swag/tree/master/example/celler/controller)
+[celler/controller](https://github.com/piiano/swag/tree/master/example/celler/controller)
 
 
-| annotation  | description                                                                                                                |
-|-------------|----------------------------------------------------------------------------------------------------------------------------|
-| description | A verbose explanation of the operation behavior.                                                                           |
-| description.markdown     |  A short description of the application. The description will be read from a file named like endpointname.md| // @description.file endpoint.description.markdown  |
-| id          | A unique string used to identify the operation. Must be unique among all API operations.                                   |
-| tags        | A list of tags to each API operation that separated by commas.                                                             |
-| summary     | A short summary of what the operation does.                                                                                |
-| accept      | A list of MIME types the APIs can consume. Note that Accept only affects operations with a request body, such as POST, PUT and PATCH.  Value MUST be as described under [Mime Types](#mime-types).                     |
-| produce     | A list of MIME types the APIs can produce. Value MUST be as described under [Mime Types](#mime-types).                     |
-| param       | Parameters that separated by spaces. `param name`,`param type`,`data type`,`is mandatory?`,`comment` `attribute(optional)` |
-| security    | [Security](#security) to each API operation.                                                                               |
-| success     | Success response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                   |
-| failure     | Failure response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                    |
-| response    | As same as `success` and `failure` |
-| header      | Header in response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                            |
-| router      | Path definition that separated by spaces. `path`,`[httpMethod]`                                                            |
-| x-name      | The extension key, must be start by x- and take only json value.                                                           |
-| x-codeSample      | Optional Markdown usage. take `file` as parameter. This will then search for a file named like the summary in the given folder.                                      |
-| deprecated  | Mark endpoint as deprecated.                                                                                               |
+| annotation           | description                                                                                                                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| description          | A verbose explanation of the operation behavior.                                                                                                                                                   |
+| description.markdown | A short description of the application. The description will be read from a file named like endpointname.md                                                                                        | // @description.file endpoint.description.markdown |
+| id                   | A unique string used to identify the operation. Must be unique among all API operations.                                                                                                           |
+| tags                 | A list of tags to each API operation that separated by commas.                                                                                                                                     |
+| summary              | A short summary of what the operation does.                                                                                                                                                        |
+| accept               | A list of MIME types the APIs can consume. Note that Accept only affects operations with a request body, such as POST, PUT and PATCH.  Value MUST be as described under [Mime Types](#mime-types). |
+| produce              | A list of MIME types the APIs can produce. Value MUST be as described under [Mime Types](#mime-types).                                                                                             |
+| param                | Parameters that separated by spaces. `param name`,`param type`,`data type`,`is mandatory?`,`comment` `attribute(optional)`                                                                         |
+| security             | [Security](#security) to each API operation.                                                                                                                                                       |
+| success              | Success response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                                                                                           |
+| failure              | Failure response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                                                                                           |
+| response             | As same as `success` and `failure`                                                                                                                                                                 |
+| header               | Header in response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                                                                                                    |
+| router               | Path definition that separated by spaces. `path`,`[httpMethod]`                                                                                                                                    |
+| x-name               | The extension key, must be start by x- and take only json value.                                                                                                                                   |
+| x-codeSample         | Optional Markdown usage. take `file` as parameter. This will then search for a file named like the summary in the given folder.                                                                    |
+| deprecated           | Mark endpoint as deprecated.                                                                                                                                                                       |
 
 
 
@@ -407,7 +407,7 @@ When a short string in your documentation is insufficient, or you need images, c
 Besides that, `swag` also accepts aliases for some MIME Types as follows:
 
 | Alias                 | MIME Type                         |
-|-----------------------|-----------------------------------|
+| --------------------- | --------------------------------- |
 | json                  | application/json                  |
 | xml                   | text/xml                          |
 | plain                 | text/plain                        |
@@ -440,18 +440,18 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 - user defined struct
 
 ## Security
-| annotation | description | parameters | example |
-|------------|-------------|------------|---------|
-| securitydefinitions.basic  | [Basic](https://swagger.io/docs/specification/2-0/authentication/basic-authentication/) auth.  |                                   | // @securityDefinitions.basic BasicAuth                      |
-| securitydefinitions.apikey | [API key](https://swagger.io/docs/specification/2-0/authentication/api-keys/) auth.            | in, name                          | // @securityDefinitions.apikey ApiKeyAuth                    |
-| securitydefinitions.oauth2.application  | [OAuth2 application](https://swagger.io/docs/specification/authentication/oauth2/) auth.       | tokenUrl, scope                   | // @securitydefinitions.oauth2.application OAuth2Application |
-| securitydefinitions.oauth2.implicit     | [OAuth2 implicit](https://swagger.io/docs/specification/authentication/oauth2/) auth.          | authorizationUrl, scope           | // @securitydefinitions.oauth2.implicit OAuth2Implicit       |
-| securitydefinitions.oauth2.password     | [OAuth2 password](https://swagger.io/docs/specification/authentication/oauth2/) auth.          | tokenUrl, scope                   | // @securitydefinitions.oauth2.password OAuth2Password       |
-| securitydefinitions.oauth2.accessCode   | [OAuth2 access code](https://swagger.io/docs/specification/authentication/oauth2/) auth.       | tokenUrl, authorizationUrl, scope | // @securitydefinitions.oauth2.accessCode OAuth2AccessCode   |
+| annotation                             | description                                                                                   | parameters                        | example                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------ |
+| securitydefinitions.basic              | [Basic](https://swagger.io/docs/specification/2-0/authentication/basic-authentication/) auth. |                                   | // @securityDefinitions.basic BasicAuth                      |
+| securitydefinitions.apikey             | [API key](https://swagger.io/docs/specification/2-0/authentication/api-keys/) auth.           | in, name                          | // @securityDefinitions.apikey ApiKeyAuth                    |
+| securitydefinitions.oauth2.application | [OAuth2 application](https://swagger.io/docs/specification/authentication/oauth2/) auth.      | tokenUrl, scope                   | // @securitydefinitions.oauth2.application OAuth2Application |
+| securitydefinitions.oauth2.implicit    | [OAuth2 implicit](https://swagger.io/docs/specification/authentication/oauth2/) auth.         | authorizationUrl, scope           | // @securitydefinitions.oauth2.implicit OAuth2Implicit       |
+| securitydefinitions.oauth2.password    | [OAuth2 password](https://swagger.io/docs/specification/authentication/oauth2/) auth.         | tokenUrl, scope                   | // @securitydefinitions.oauth2.password OAuth2Password       |
+| securitydefinitions.oauth2.accessCode  | [OAuth2 access code](https://swagger.io/docs/specification/authentication/oauth2/) auth.      | tokenUrl, authorizationUrl, scope | // @securitydefinitions.oauth2.accessCode OAuth2AccessCode   |
 
 
 | parameters annotation | example                                                  |
-|-----------------------|----------------------------------------------------------|
+| --------------------- | -------------------------------------------------------- |
 | in                    | // @in header                                            |
 | name                  | // @name Authorization                                   |
 | tokenUrl              | // @tokenUrl https://example.com/oauth/token             |
@@ -484,28 +484,28 @@ type Foo struct {
 
 ### Available
 
-Field Name | Type | Description
----|:---:|---
-<a name="validate"></a>validate | `string` | 	Determines the validation for the parameter. Possible values are: `required`. 
-<a name="parameterDefault"></a>default | * | Declares the value of the parameter that the server will use if none is provided, for example a "count" to control the number of results per page might default to 100 if not supplied by the client in the request. (Note: "default" has no meaning for required parameters.)  See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#parameterType) for this parameter.
-<a name="parameterMaximum"></a>maximum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
-<a name="parameterMinimum"></a>minimum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.
-<a name="parameterMultipleOf"></a>multipleOf | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.
-<a name="parameterMaxLength"></a>maxLength | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.
-<a name="parameterMinLength"></a>minLength | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.
-<a name="parameterEnums"></a>enums | [\*] | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
-<a name="parameterFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](https://swagger.io/specification/v2/#dataTypeFormat) for further details.
-<a name="parameterCollectionFormat"></a>collectionFormat | `string` |Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
-<a name="parameterExtensions"></a>extensions | `string` | Add extension to parameters.
+| Field Name                                               |   Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| <a name="validate"></a>validate                          | `string`  | Determines the validation for the parameter. Possible values are: `required`.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| <a name="parameterDefault"></a>default                   |     *     | Declares the value of the parameter that the server will use if none is provided, for example a "count" to control the number of results per page might default to 100 if not supplied by the client in the request. (Note: "default" has no meaning for required parameters.)  See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#parameterType) for this parameter.                                                              |
+| <a name="parameterMaximum"></a>maximum                   | `number`  | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterMinimum"></a>minimum                   | `number`  | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterMultipleOf"></a>multipleOf             | `number`  | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.1.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterMaxLength"></a>maxLength               | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterMinLength"></a>minLength               | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterEnums"></a>enums                       |   [\*]    | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| <a name="parameterFormat"></a>format                     | `string`  | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](https://swagger.io/specification/v2/#dataTypeFormat) for further details.                                                                                                                                                                                                                                                                                                                                                        |
+| <a name="parameterCollectionFormat"></a>collectionFormat | `string`  | Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`. |
+| <a name="parameterExtensions"></a>extensions             | `string`  | Add extension to parameters.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 ### Future
 
-Field Name | Type | Description
----|:---:|---
-<a name="parameterPattern"></a>pattern | `string` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3.
-<a name="parameterMaxItems"></a>maxItems | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
-<a name="parameterMinItems"></a>minItems | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
-<a name="parameterUniqueItems"></a>uniqueItems | `boolean` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
+| Field Name                                     |   Type    | Description                                                                        |
+| ---------------------------------------------- | :-------: | ---------------------------------------------------------------------------------- |
+| <a name="parameterPattern"></a>pattern         | `string`  | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3. |
+| <a name="parameterMaxItems"></a>maxItems       | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2. |
+| <a name="parameterMinItems"></a>minItems       | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3. |
+| <a name="parameterUniqueItems"></a>uniqueItems | `boolean` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4. |
 
 ## Examples
 
@@ -648,7 +648,7 @@ So, generated swagger doc as follows:
 ```
 
 ### Use swaggertype tag to supported custom type
-[#201](https://github.com/swaggo/swag/issues/201#issuecomment-475479409)
+[#201](https://github.com/piiano/swag/issues/201#issuecomment-475479409)
 
 ```go
 type TimestampTime struct {
@@ -684,7 +684,7 @@ type Account struct {
 }
 ```
 
-[#379](https://github.com/swaggo/swag/issues/379)
+[#379](https://github.com/piiano/swag/issues/379)
 ```go
 type CerticateKeyPair struct {
 	Crt []byte `json:"crt" swaggertype:"string" format:"base64" example:"U3dhZ2dlciByb2Nrcw=="`
@@ -838,7 +838,7 @@ This project was inspired by [yvasiyarov/swagger](https://github.com/yvasiyarov/
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/swaggo/swag/graphs/contributors"><img src="https://opencollective.com/swag/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/piiano/swag/graphs/contributors"><img src="https://opencollective.com/swag/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -6,12 +6,12 @@
 
 [![Travis Status](https://img.shields.io/travis/swaggo/swag/master.svg)](https://travis-ci.org/swaggo/swag)
 [![Coverage Status](https://img.shields.io/codecov/c/github/swaggo/swag/master.svg)](https://codecov.io/gh/swaggo/swag)
-[![Go Report Card](https://goreportcard.com/badge/github.com/swaggo/swag)](https://goreportcard.com/report/github.com/swaggo/swag)
+[![Go Report Card](https://goreportcard.com/badge/github.com/piiano/swag)](https://goreportcard.com/report/github.com/piiano/swag)
 [![codebeat badge](https://codebeat.co/badges/71e2f5e5-9e6b-405d-baf9-7cc8b5037330)](https://codebeat.co/projects/github-com-swaggo-swag-master)
-[![Go Doc](https://godoc.org/github.com/swaggo/swagg?status.svg)](https://godoc.org/github.com/swaggo/swag)
+[![Go Doc](https://godoc.org/github.com/piiano/swagg?status.svg)](https://godoc.org/github.com/piiano/swag)
 [![Backers on Open Collective](https://opencollective.com/swag/backers/badge.svg)](#backers) 
 [![Sponsors on Open Collective](https://opencollective.com/swag/sponsors/badge.svg)](#sponsors) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fswaggo%2Fswag.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fswaggo%2Fswag?ref=badge_shield)
-[![Release](https://img.shields.io/github/release/swaggo/swag.svg?style=flat-square)](https://github.com/swaggo/swag/releases)
+[![Release](https://img.shields.io/github/release/swaggo/swag.svg?style=flat-square)](https://github.com/piiano/swag/releases)
 
 Swag将Go的注释转换为Swagger2.0文档。我们为流行的 [Go Web Framework](#支持的Web框架) 创建了各种插件，这样可以与现有Go项目快速集成（使用Swagger UI）。
 
@@ -47,10 +47,10 @@ Swag将Go的注释转换为Swagger2.0文档。我们为流行的 [Go Web Framewo
 2. 使用如下命令下载swag：
 
 ```bash
-$ go get -u github.com/swaggo/swag/cmd/swag
+$ go get -u github.com/piiano/swag/cmd/swag
 
 # 1.16 及以上版本
-$ go install github.com/swaggo/swag/cmd/swag@latest
+$ go install github.com/piiano/swag/cmd/swag@latest
 ```
 
 从源码开始构建的话，需要有Go环境（1.15及以上版本）。
@@ -126,7 +126,7 @@ OPTIONS:
 
 ## 如何与Gin集成
 
-[点击此处](https://github.com/swaggo/swag/tree/master/example/celler)查看示例源代码。
+[点击此处](https://github.com/piiano/swag/tree/master/example/celler)查看示例源代码。
 
 1. 使用`swag init`生成Swagger2.0文档后，导入如下代码包：
 
@@ -227,8 +227,8 @@ import (
     "strconv"
 
     "github.com/gin-gonic/gin"
-    "github.com/swaggo/swag/example/celler/httputil"
-    "github.com/swaggo/swag/example/celler/model"
+    "github.com/piiano/swag/example/celler/httputil"
+    "github.com/piiano/swag/example/celler/model"
 )
 
 // ShowAccount godoc
@@ -293,7 +293,7 @@ swag init
 ## 格式化说明
 
 可以针对Swag的注释自动格式化，就像`go fmt`。   
-此处查看格式化结果 [here](https://github.com/swaggo/swag/tree/master/example/celler).
+此处查看格式化结果 [here](https://github.com/piiano/swag/tree/master/example/celler).
 
 示例：
 ```shell
@@ -329,30 +329,30 @@ swag fmt -d ./ --exclude ./internal
 
 ## 通用API信息
 
-**示例** [`celler/main.go`](https://github.com/swaggo/swag/blob/master/example/celler/main.go)
+**示例** [`celler/main.go`](https://github.com/piiano/swag/blob/master/example/celler/main.go)
 
-| 注释                    | 说明                                                                                            | 示例                                                            |
-| ----------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| title                   | **必填** 应用程序的名称。                                                                       | // @title Swagger Example API                                   |
-| version                 | **必填** 提供应用程序API的版本。                                                                | // @version 1.0                                                 |
-| description             | 应用程序的简短描述。                                                                            | // @description This is a sample server celler server.          |
-| tag.name                | 标签的名称。                                                                                    | // @tag.name This is the name of the tag                        |
-| tag.description         | 标签的描述。                                                                                    | // @tag.description Cool Description                            |
-| tag.docs.url            | 标签的外部文档的URL。                                                                           | // @tag.docs.url https://example.com                            |
-| tag.docs.description    | 标签的外部文档说明。                                                                            | // @tag.docs.description Best example documentation             |
-| termsOfService          | API的服务条款。                                                                                 | // @termsOfService http://swagger.io/terms/                     |
-| contact.name            | 公开的API的联系信息。                                                                           | // @contact.name API Support                                    |
-| contact.url             | 联系信息的URL。 必须采用网址格式。                                                              | // @contact.url http://www.swagger.io/support                   |
-| contact.email           | 联系人/组织的电子邮件地址。 必须采用电子邮件地址的格式。                                        | // @contact.email support@swagger.io                            |
-| license.name            | **必填** 用于API的许可证名称。                                                                  | // @license.name Apache 2.0                                     |
-| license.url             | 用于API的许可证的URL。 必须采用网址格式。                                                       | // @license.url http://www.apache.org/licenses/LICENSE-2.0.html |
-| host                    | 运行API的主机（主机名或IP地址）。                                                               | // @host localhost:8080                                         |
-| BasePath                | 运行API的基本路径。                                                                             | // @BasePath /api/v1                                            |
-| accept                  | API 可以使用的 MIME 类型列表。 请注意，Accept 仅影响具有请求正文的操作，例如 POST、PUT 和 PATCH。 值必须如“[Mime类型](#mime-types)”中所述。                                  | // @accept json |
-| produce                 | API可以生成的MIME类型的列表。值必须如“[Mime类型](#mime-types)”中所述。                                  | // @produce json |
-| query.collection.format | 请求URI query里数组参数的默认格式：csv，multi，pipes，tsv，ssv。 如果未设置，则默认为csv。 | // @query.collection.format multi                               |
-| schemes                 | 用空格分隔的请求的传输协议。                                                                    | // @schemes http https                                          |
-| x-name                  | 扩展的键必须以x-开头，并且只能使用json值                                                        | // @x-example-key {"key": "value"}                              |
+| 注释                    | 说明                                                                                                                                        | 示例                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| title                   | **必填** 应用程序的名称。                                                                                                                   | // @title Swagger Example API                                   |
+| version                 | **必填** 提供应用程序API的版本。                                                                                                            | // @version 1.0                                                 |
+| description             | 应用程序的简短描述。                                                                                                                        | // @description This is a sample server celler server.          |
+| tag.name                | 标签的名称。                                                                                                                                | // @tag.name This is the name of the tag                        |
+| tag.description         | 标签的描述。                                                                                                                                | // @tag.description Cool Description                            |
+| tag.docs.url            | 标签的外部文档的URL。                                                                                                                       | // @tag.docs.url https://example.com                            |
+| tag.docs.description    | 标签的外部文档说明。                                                                                                                        | // @tag.docs.description Best example documentation             |
+| termsOfService          | API的服务条款。                                                                                                                             | // @termsOfService http://swagger.io/terms/                     |
+| contact.name            | 公开的API的联系信息。                                                                                                                       | // @contact.name API Support                                    |
+| contact.url             | 联系信息的URL。 必须采用网址格式。                                                                                                          | // @contact.url http://www.swagger.io/support                   |
+| contact.email           | 联系人/组织的电子邮件地址。 必须采用电子邮件地址的格式。                                                                                    | // @contact.email support@swagger.io                            |
+| license.name            | **必填** 用于API的许可证名称。                                                                                                              | // @license.name Apache 2.0                                     |
+| license.url             | 用于API的许可证的URL。 必须采用网址格式。                                                                                                   | // @license.url http://www.apache.org/licenses/LICENSE-2.0.html |
+| host                    | 运行API的主机（主机名或IP地址）。                                                                                                           | // @host localhost:8080                                         |
+| BasePath                | 运行API的基本路径。                                                                                                                         | // @BasePath /api/v1                                            |
+| accept                  | API 可以使用的 MIME 类型列表。 请注意，Accept 仅影响具有请求正文的操作，例如 POST、PUT 和 PATCH。 值必须如“[Mime类型](#mime-types)”中所述。 | // @accept json                                                 |
+| produce                 | API可以生成的MIME类型的列表。值必须如“[Mime类型](#mime-types)”中所述。                                                                      | // @produce json                                                |
+| query.collection.format | 请求URI query里数组参数的默认格式：csv，multi，pipes，tsv，ssv。 如果未设置，则默认为csv。                                                  | // @query.collection.format multi                               |
+| schemes                 | 用空格分隔的请求的传输协议。                                                                                                                | // @schemes http https                                          |
+| x-name                  | 扩展的键必须以x-开头，并且只能使用json值                                                                                                    | // @x-example-key {"key": "value"}                              |
 
 ### 使用Markdown描述
 
@@ -368,25 +368,25 @@ swag fmt -d ./ --exclude ./internal
 
 ## API操作
 
-Example [celler/controller](https://github.com/swaggo/swag/tree/master/example/celler/controller)
+Example [celler/controller](https://github.com/piiano/swag/tree/master/example/celler/controller)
 
-| 注释                 | 描述                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------- |
-| description          | 操作行为的详细说明。                                                                                    |
-| description.markdown | 应用程序的简短描述。该描述将从名为`endpointname.md`的文件中读取。                                       |
-| id                   | 用于标识操作的唯一字符串。在所有API操作中必须唯一。                                                     |
-| tags                 | 每个API操作的标签列表，以逗号分隔。                                                                     |
-| summary              | 该操作的简短摘要。                                                                                      |
-| accept               | API 可以使用的 MIME 类型列表。 请注意，Accept 仅影响具有请求正文的操作，例如 POST、PUT 和 PATCH。 值必须如“[Mime类型](#mime-types)”中所述。                                  |
-| produce              | API可以生成的MIME类型的列表。值必须如“[Mime类型](#mime-types)”中所述。                                  |
-| param                | 用空格分隔的参数。`param name`,`param type`,`data type`,`is mandatory?`,`comment` `attribute(optional)` |
-| security             | 每个API操作的[安全性](#安全性)。                                                                      |
-| success              | 以空格分隔的成功响应。`return code`,`{param type}`,`data type`,`comment`                                |
-| failure              | 以空格分隔的故障响应。`return code`,`{param type}`,`data type`,`comment`                                |
-| response             | 与success、failure作用相同                                                                               |
-| header               | 以空格分隔的头字段。 `return code`,`{param type}`,`data type`,`comment`                                 |
-| router               | 以空格分隔的路径定义。 `path`,`[httpMethod]`                                                            |
-| x-name               | 扩展字段必须以`x-`开头，并且只能使用json值。                                                            |
+| 注释                 | 描述                                                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| description          | 操作行为的详细说明。                                                                                                                        |
+| description.markdown | 应用程序的简短描述。该描述将从名为`endpointname.md`的文件中读取。                                                                           |
+| id                   | 用于标识操作的唯一字符串。在所有API操作中必须唯一。                                                                                         |
+| tags                 | 每个API操作的标签列表，以逗号分隔。                                                                                                         |
+| summary              | 该操作的简短摘要。                                                                                                                          |
+| accept               | API 可以使用的 MIME 类型列表。 请注意，Accept 仅影响具有请求正文的操作，例如 POST、PUT 和 PATCH。 值必须如“[Mime类型](#mime-types)”中所述。 |
+| produce              | API可以生成的MIME类型的列表。值必须如“[Mime类型](#mime-types)”中所述。                                                                      |
+| param                | 用空格分隔的参数。`param name`,`param type`,`data type`,`is mandatory?`,`comment` `attribute(optional)`                                     |
+| security             | 每个API操作的[安全性](#安全性)。                                                                                                            |
+| success              | 以空格分隔的成功响应。`return code`,`{param type}`,`data type`,`comment`                                                                    |
+| failure              | 以空格分隔的故障响应。`return code`,`{param type}`,`data type`,`comment`                                                                    |
+| response             | 与success、failure作用相同                                                                                                                  |
+| header               | 以空格分隔的头字段。 `return code`,`{param type}`,`data type`,`comment`                                                                     |
+| router               | 以空格分隔的路径定义。 `path`,`[httpMethod]`                                                                                                |
+| x-name               | 扩展字段必须以`x-`开头，并且只能使用json值。                                                                                                |
 
 ## Mime类型
 
@@ -467,15 +467,15 @@ type Foo struct {
 
 ### 当前可用的
 
-| 字段名           | 类型      | 描述                                                                                                                                                                                                                                                                                                                                                                  |
-| ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| default          | *         | 声明如果未提供任何参数，则服务器将使用的默认参数值，例如，如果请求中的客户端未提供该参数，则用于控制每页结果数的“计数”可能默认为100。 （注意：“default”对于必需的参数没有意义）。参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2。 与JSON模式不同，此值务必符合此参数的定义[类型](#parameterType)。                                  |
-| maximum          | `number`  | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.                                                                                                                                                                                                                                                                                   |
-| minimum          | `number`  | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.                                                                                                                                                                                                                                                                                   |
-| maxLength        | `integer` | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.                                                                                                                                                                                                                                                                                   |
-| minLength        | `integer` | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.                                                                                                                                                                                                                                                                                   |
-| enums            | [\*]      | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.                                                                                                                                                                                                                                                                                   |
-| format           | `string`  | 上面提到的[类型](#parameterType)的扩展格式。有关更多详细信息，请参见[数据类型格式](https://swagger.io/specification/v2/#dataTypeFormat)。                                                                                                                                                                                                                             |
+| 字段名           | 类型      | 描述                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| default          | *         | 声明如果未提供任何参数，则服务器将使用的默认参数值，例如，如果请求中的客户端未提供该参数，则用于控制每页结果数的“计数”可能默认为100。 （注意：“default”对于必需的参数没有意义）。参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2。 与JSON模式不同，此值务必符合此参数的定义[类型](#parameterType)。                       |
+| maximum          | `number`  | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.                                                                                                                                                                                                                                                                        |
+| minimum          | `number`  | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.                                                                                                                                                                                                                                                                        |
+| maxLength        | `integer` | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.1.                                                                                                                                                                                                                                                                        |
+| minLength        | `integer` | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.                                                                                                                                                                                                                                                                        |
+| enums            | [\*]      | 参看 https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.                                                                                                                                                                                                                                                                        |
+| format           | `string`  | 上面提到的[类型](#parameterType)的扩展格式。有关更多详细信息，请参见[数据类型格式](https://swagger.io/specification/v2/#dataTypeFormat)。                                                                                                                                                                                                                  |
 | collectionFormat | `string`  | 指定query数组参数的格式。 可能的值为： <ul><li>`csv` - 逗号分隔值 `foo,bar`. <li>`ssv` - 空格分隔值 `foo bar`. <li>`tsv` - 制表符分隔值 `foo\tbar`. <li>`pipes` - 管道符分隔值 <code>foo&#124;bar</code>. <li>`multi` - 对应于多个参数实例，而不是单个实例 `foo=bar＆foo=baz` 的多个值。这仅对“`query`”或“`formData`”中的参数有效。 </ul> 默认值是 `csv`。 |
 
 ### 进一步的
@@ -591,7 +591,7 @@ type Account struct {
 
 ### 使用`swaggertype`标签更改字段类型
 
-[#201](https://github.com/swaggo/swag/issues/201#issuecomment-475479409)
+[#201](https://github.com/piiano/swag/issues/201#issuecomment-475479409)
 
 ```go
 type TimestampTime struct {
@@ -628,7 +628,7 @@ type Account struct {
 }
 ```
 
-[#379](https://github.com/swaggo/swag/issues/379)
+[#379](https://github.com/piiano/swag/issues/379)
 
 ```go
 type CerticateKeyPair struct {
@@ -732,7 +732,7 @@ This project was inspired by [yvasiyarov/swagger](https://github.com/yvasiyarov/
 ## 贡献者
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="https://github.com/swaggo/swag/graphs/contributors"><img src="https://opencollective.com/swag/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/piiano/swag/graphs/contributors"><img src="https://opencollective.com/swag/contributors.svg?width=890&button=false" /></a>
 
 ## 支持者
 

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/urfave/cli/v2"
-
 	"github.com/swaggo/swag"
 	"github.com/swaggo/swag/format"
 	"github.com/swaggo/swag/gen"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -75,17 +74,17 @@ var initFlags = []cli.Flag{
 		Aliases: []string{"pd"},
 		Usage:   "Parse go files inside dependency folder, disabled by default",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		Name:    markdownFilesFlag,
 		Aliases: []string{"md"},
-		Value:   "",
-		Usage:   "Parse folder containing markdown files to use as description, disabled by default",
+		Value:   nil,
+		Usage:   "Parse folders containing markdown files to use as description, disabled by default",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		Name:    codeExampleFilesFlag,
 		Aliases: []string{"cef"},
-		Value:   "",
-		Usage:   "Parse folder containing code example files to use for the x-codeSamples extension, disabled by default",
+		Value:   nil,
+		Usage:   "Parse folders containing code example files to use for the x-codeSamples extension, disabled by default",
 	},
 	&cli.BoolFlag{
 		Name:  parseInternalFlag,
@@ -127,21 +126,21 @@ func initAction(c *cli.Context) error {
 	}
 
 	return gen.New().Build(&gen.Config{
-		SearchDir:           c.String(searchDirFlag),
-		Excludes:            c.String(excludeFlag),
-		MainAPIFile:         c.String(generalInfoFlag),
-		PropNamingStrategy:  strategy,
-		OutputDir:           c.String(outputFlag),
-		OutputTypes:         outputTypes,
-		ParseVendor:         c.Bool(parseVendorFlag),
-		ParseDependency:     c.Bool(parseDependencyFlag),
-		MarkdownFilesDir:    c.String(markdownFilesFlag),
-		ParseInternal:       c.Bool(parseInternalFlag),
-		GeneratedTime:       c.Bool(generatedTimeFlag),
-		CodeExampleFilesDir: c.String(codeExampleFilesFlag),
-		ParseDepth:          c.Int(parseDepthFlag),
-		InstanceName:        c.String(instanceNameFlag),
-		OverridesFile:       c.String(overridesFileFlag),
+		SearchDir:            c.String(searchDirFlag),
+		Excludes:             c.String(excludeFlag),
+		MainAPIFile:          c.String(generalInfoFlag),
+		PropNamingStrategy:   strategy,
+		OutputDir:            c.String(outputFlag),
+		OutputTypes:          outputTypes,
+		ParseVendor:          c.Bool(parseVendorFlag),
+		ParseDependency:      c.Bool(parseDependencyFlag),
+		MarkdownFilesDirs:    c.StringSlice(markdownFilesFlag),
+		ParseInternal:        c.Bool(parseInternalFlag),
+		GeneratedTime:        c.Bool(generatedTimeFlag),
+		CodeExampleFilesDirs: c.StringSlice(codeExampleFilesFlag),
+		ParseDepth:           c.Int(parseDepthFlag),
+		InstanceName:         c.String(instanceNameFlag),
+		OverridesFile:        c.String(overridesFileFlag),
 	})
 }
 

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/swaggo/swag"
-	"github.com/swaggo/swag/format"
-	"github.com/swaggo/swag/gen"
+	"github.com/piiano/swag"
+	"github.com/piiano/swag/format"
+	"github.com/piiano/swag/gen"
 	"github.com/urfave/cli/v2"
 )
 

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
 Package swag converts Go annotations to Swagger Documentation 2.0.
-See https://github.com/swaggo/swag for more information about swag.
+See https://github.com/piiano/swag for more information about swag.
 */
-package swag // import "github.com/swaggo/swag"
+package swag // import "github.com/piiano/swag"

--- a/example/basic/api/api.go
+++ b/example/basic/api/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/swaggo/swag/example/basic/web"
+	"github.com/piiano/swag/example/basic/web"
 )
 
 // GetStringByInt example

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/example/basic/api"
+	"github.com/piiano/swag/example/basic/api"
 )
 
 // @title Swagger Example API

--- a/example/celler/README.md
+++ b/example/celler/README.md
@@ -3,7 +3,7 @@
 Gen doc
 
 ```console
-$ go get -u github.com/swaggo/swag/cmd/swag
+$ go get -u github.com/piiano/swag/cmd/swag
 $ swag init
 ```
 

--- a/example/celler/controller/admin.go
+++ b/example/celler/controller/admin.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/swaggo/swag/example/celler/httputil"
-	"github.com/swaggo/swag/example/celler/model"
+	"github.com/piiano/swag/example/celler/httputil"
+	"github.com/piiano/swag/example/celler/model"
 )
 
 // Auth godoc

--- a/example/celler/controller/bottles.go
+++ b/example/celler/controller/bottles.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/swaggo/swag/example/celler/httputil"
-	"github.com/swaggo/swag/example/celler/model"
+	"github.com/piiano/swag/example/celler/httputil"
+	"github.com/piiano/swag/example/celler/model"
 )
 
 // ShowBottle godoc

--- a/example/celler/controller/examples.go
+++ b/example/celler/controller/examples.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/swaggo/swag/example/celler/httputil"
+	"github.com/piiano/swag/example/celler/httputil"
 )
 
 // PingExample godoc

--- a/example/celler/go.mod
+++ b/example/celler/go.mod
@@ -1,4 +1,4 @@
-module github.com/swaggo/swag/example/celler
+module github.com/piiano/swag/example/celler
 
 go 1.17
 
@@ -7,7 +7,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2
 	github.com/swaggo/gin-swagger v1.3.3
-	github.com/swaggo/swag v1.7.4
+	github.com/piiano/swag v1.7.4
 )
 
 require (

--- a/example/celler/go.sum
+++ b/example/celler/go.sum
@@ -83,8 +83,8 @@ github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2 h1:+iNTcqQJy0OZ5jk6a5
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/gin-swagger v1.3.3 h1:XHyYmeNVFG5PbyWHG4jXtxOm2P4kiZapDCWsyDDiQ/I=
 github.com/swaggo/gin-swagger v1.3.3/go.mod h1:ymsZuGpbbu+S7ZoQ49QPpZoDBj6uqhb8WizgQPVgWl0=
-github.com/swaggo/swag v1.7.4 h1:up+ixy8yOqJKiFcuhMgkuYuF4xnevuhnFAXXF8OSfNg=
-github.com/swaggo/swag v1.7.4/go.mod h1:zD8h6h4SPv7t3l+4BKdRquqW1ASWjKZgT6Qv9z3kNqI=
+github.com/piiano/swag v1.7.4 h1:up+ixy8yOqJKiFcuhMgkuYuF4xnevuhnFAXXF8OSfNg=
+github.com/piiano/swag v1.7.4/go.mod h1:zD8h6h4SPv7t3l+4BKdRquqW1ASWjKZgT6Qv9z3kNqI=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/example/celler/main.go
+++ b/example/celler/main.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/swaggo/swag/example/celler/controller"
-	_ "github.com/swaggo/swag/example/celler/docs"
-	"github.com/swaggo/swag/example/celler/httputil"
+	"github.com/piiano/swag/example/celler/controller"
+	_ "github.com/piiano/swag/example/celler/docs"
+	"github.com/piiano/swag/example/celler/httputil"
 
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"

--- a/example/go-module-support/go.mod
+++ b/example/go-module-support/go.mod
@@ -1,4 +1,4 @@
-module github.com/swaggo/swag/example/go-module-support
+module github.com/piiano/swag/example/go-module-support
 
 go 1.17
 

--- a/example/markdown/docs/docs.go
+++ b/example/markdown/docs/docs.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/swaggo/swag"
+	"github.com/piiano/swag"
 )
 
 var doc = `{

--- a/example/markdown/go.mod
+++ b/example/markdown/go.mod
@@ -1,11 +1,11 @@
-module github.com/swaggo/swag/example/markdown
+module github.com/piiano/swag/example/markdown
 
 go 1.17
 
 require (
 	github.com/gorilla/mux v1.7.3
 	github.com/swaggo/http-swagger v1.1.2
-	github.com/swaggo/swag v1.7.0
+	github.com/piiano/swag v1.7.0
 )
 
 require (

--- a/example/markdown/go.sum
+++ b/example/markdown/go.sum
@@ -53,8 +53,8 @@ github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2 h1:+iNTcqQJy0OZ5jk6a5
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/http-swagger v1.1.2 h1:ikcSD+EUOx+2oNZ2N6u8IYa8ScOsAvE7Jh+E1dW6i94=
 github.com/swaggo/http-swagger v1.1.2/go.mod h1:mX5nhypDmoSt4iw2mc5aKXxRFvp1CLLcCiog2B9M+Ro=
-github.com/swaggo/swag v1.7.0 h1:5bCA/MTLQoIqDXXyHfOpMeDvL9j68OY/udlK4pQoo4E=
-github.com/swaggo/swag v1.7.0/go.mod h1:BdPIL73gvS9NBsdi7M1JOxLvlbfvNRaBP8m6WT6Aajo=
+github.com/piiano/swag v1.7.0 h1:5bCA/MTLQoIqDXXyHfOpMeDvL9j68OY/udlK4pQoo4E=
+github.com/piiano/swag v1.7.0/go.mod h1:BdPIL73gvS9NBsdi7M1JOxLvlbfvNRaBP8m6WT6Aajo=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/example/markdown/main.go
+++ b/example/markdown/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/gorilla/mux"
-	httpSwagger "github.com/swaggo/http-swagger"
-	"github.com/swaggo/swag/example/markdown/api"
-	_ "github.com/swaggo/swag/example/markdown/docs"
 	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/piiano/swag/example/markdown/api"
+	_ "github.com/piiano/swag/example/markdown/docs"
+	httpSwagger "github.com/swaggo/http-swagger"
 )
 
 // @title Swagger Example API

--- a/example/object-map-example/docs/docs.go
+++ b/example/object-map-example/docs/docs.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/swaggo/swag"
+	"github.com/piiano/swag"
 )
 
 var doc = `{

--- a/example/object-map-example/go.mod
+++ b/example/object-map-example/go.mod
@@ -1,4 +1,4 @@
-module github.com/swaggo/swag/example/object-map-example
+module github.com/piiano/swag/example/object-map-example
 
 go 1.17
 
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2
 	github.com/swaggo/gin-swagger v1.3.3
-	github.com/swaggo/swag v1.7.4
+	github.com/piiano/swag v1.7.4
 )
 
 require (

--- a/example/object-map-example/go.sum
+++ b/example/object-map-example/go.sum
@@ -81,8 +81,8 @@ github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2 h1:+iNTcqQJy0OZ5jk6a5
 github.com/swaggo/files v0.0.0-20210815190702-a29dd2bc99b2/go.mod h1:lKJPbtWzJ9JhsTN1k1gZgleJWY/cqq0psdoMmaThG3w=
 github.com/swaggo/gin-swagger v1.3.3 h1:XHyYmeNVFG5PbyWHG4jXtxOm2P4kiZapDCWsyDDiQ/I=
 github.com/swaggo/gin-swagger v1.3.3/go.mod h1:ymsZuGpbbu+S7ZoQ49QPpZoDBj6uqhb8WizgQPVgWl0=
-github.com/swaggo/swag v1.7.4 h1:up+ixy8yOqJKiFcuhMgkuYuF4xnevuhnFAXXF8OSfNg=
-github.com/swaggo/swag v1.7.4/go.mod h1:zD8h6h4SPv7t3l+4BKdRquqW1ASWjKZgT6Qv9z3kNqI=
+github.com/piiano/swag v1.7.4 h1:up+ixy8yOqJKiFcuhMgkuYuF4xnevuhnFAXXF8OSfNg=
+github.com/piiano/swag v1.7.4/go.mod h1:zD8h6h4SPv7t3l+4BKdRquqW1ASWjKZgT6Qv9z3kNqI=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/example/object-map-example/main.go
+++ b/example/object-map-example/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/swaggo/swag/example/object-map-example/controller"
-	_ "github.com/swaggo/swag/example/object-map-example/docs"
+	"github.com/piiano/swag/example/object-map-example/controller"
+	_ "github.com/piiano/swag/example/object-map-example/docs"
 
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"

--- a/format/format.go
+++ b/format/format.go
@@ -3,7 +3,7 @@ package format
 import (
 	"log"
 
-	"github.com/swaggo/swag"
+	"github.com/piiano/swag"
 )
 
 type Fmt struct {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/go-openapi/spec"
-	"github.com/swaggo/swag"
+	"github.com/piiano/swag"
 )
 
 var open = os.Open
@@ -411,7 +411,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/swaggo/swag"
+	"github.com/piiano/swag"
 )
 
 var doc = ` + "`{{ printDoc .Doc}}`" + `

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -77,11 +77,11 @@ type Config struct {
 	// PropNamingStrategy represents property naming strategy like snake case,camel case,pascal case
 	PropNamingStrategy string
 
-	// MarkdownFilesDir used to find markdown files, which can be used for tag descriptions
-	MarkdownFilesDir string
+	// MarkdownFilesDirs used to find markdown files, which can be used for tag descriptions
+	MarkdownFilesDirs []string
 
-	// CodeExampleFilesDir used to find code example files, which can be used for x-codeSamples
-	CodeExampleFilesDir string
+	// CodeExampleFilesDirs used to find code example files, which can be used for x-codeSamples
+	CodeExampleFilesDirs []string
 
 	// InstanceName is used to get distinct names for different swagger documents in the
 	// same project. The default value is "swagger".
@@ -141,9 +141,9 @@ func (g *Gen) Build(config *Config) error {
 	}
 
 	log.Println("Generate swagger docs....")
-	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
+	p := swag.New(swag.SetMarkdownFileDirectories(config.MarkdownFilesDirs...),
 		swag.SetExcludedDirsAndFiles(config.Excludes),
-		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir),
+		swag.SetCodeExamplesDirectories(config.CodeExampleFilesDirs...),
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),
 	)

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -175,11 +175,11 @@ func TestGen_BuildLowerCamelcase(t *testing.T) {
 
 func TestGen_BuildDescriptionWithQuotes(t *testing.T) {
 	config := &Config{
-		SearchDir:        "../testdata/quotes",
-		MainAPIFile:      "./main.go",
-		OutputDir:        "../testdata/quotes/docs",
-		OutputTypes:      outputTypes,
-		MarkdownFilesDir: "../testdata/quotes",
+		SearchDir:         "../testdata/quotes",
+		MainAPIFile:       "./main.go",
+		OutputDir:         "../testdata/quotes/docs",
+		OutputTypes:       outputTypes,
+		MarkdownFilesDirs: []string{"../testdata/quotes"},
 	}
 
 	require.NoError(t, New().Build(config))

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 
 	"github.com/go-openapi/spec"
+	"github.com/piiano/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/swaggo/swag"
 )
 
 const searchDir = "../testdata/simple"
@@ -194,7 +194,7 @@ func TestGen_BuildDescriptionWithQuotes(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-	cmd := exec.Command("go", "build", "-buildmode=plugin", "github.com/swaggo/swag/testdata/quotes")
+	cmd := exec.Command("go", "build", "-buildmode=plugin", "github.com/piiano/swag/testdata/quotes")
 	cmd.Dir = config.SearchDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/swaggo/swag
+module github.com/piiano/swag
 
 go 1.17
 

--- a/operation.go
+++ b/operation.go
@@ -27,8 +27,8 @@ type RouteProperties struct {
 // Operation describes a single API operation on a path.
 // For more information: https://github.com/swaggo/swag#api-operation
 type Operation struct {
-	parser              *Parser
-	codeExampleFilesDir string
+	parser               *Parser
+	codeExampleFilesDirs []string
 	spec.Operation
 	RouterProperties []RouteProperties
 }
@@ -81,10 +81,10 @@ func NewOperation(parser *Parser, options ...func(*Operation)) *Operation {
 	return result
 }
 
-// SetCodeExampleFilesDirectory sets the directory to search for codeExamples.
-func SetCodeExampleFilesDirectory(directoryPath string) func(*Operation) {
+// SetCodeExampleFilesDirectories sets the directories to search for codeExamples.
+func SetCodeExampleFilesDirectories(directoryPaths ...string) func(*Operation) {
 	return func(o *Operation) {
-		o.codeExampleFilesDir = directoryPath
+		o.codeExampleFilesDirs = directoryPaths
 	}
 }
 
@@ -103,7 +103,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	case descriptionAttr:
 		operation.ParseDescriptionComment(lineRemainder)
 	case descriptionMarkdownAttr:
-		commentInfo, err := getMarkdownForTag(lineRemainder, operation.parser.markdownFileDir)
+		commentInfo, err := getMarkdownForTag(lineRemainder, operation.parser.markdownFileDirs)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 // ParseCodeSample godoc.
 func (operation *Operation) ParseCodeSample(attribute, _, lineRemainder string) error {
 	if lineRemainder == "file" {
-		data, err := getCodeExampleForSummary(operation.Summary, operation.codeExampleFilesDir)
+		data, err := getCodeExampleForSummary(operation.Summary, operation.codeExampleFilesDirs)
 		if err != nil {
 			return err
 		}
@@ -1031,30 +1031,33 @@ func createParameter(paramType, description, paramName, schemaType string, requi
 	return result
 }
 
-func getCodeExampleForSummary(summaryName string, dirPath string) ([]byte, error) {
-	filesInfos, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return nil, err
-	}
+func getCodeExampleForSummary(summaryName string, dirPaths []string) ([]byte, error) {
+	for _, dirPath := range dirPaths {
 
-	for _, fileInfo := range filesInfos {
-		if fileInfo.IsDir() {
-			continue
-		}
-		fileName := fileInfo.Name()
-
-		if !strings.Contains(fileName, ".json") {
-			continue
+		filesInfos, err := ioutil.ReadDir(dirPath)
+		if err != nil {
+			return nil, err
 		}
 
-		if strings.Contains(fileName, summaryName) {
-			fullPath := filepath.Join(dirPath, fileName)
-			commentInfo, err := ioutil.ReadFile(fullPath)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to read code example file %s error: %s ", fullPath, err)
+		for _, fileInfo := range filesInfos {
+			if fileInfo.IsDir() {
+				continue
+			}
+			fileName := fileInfo.Name()
+
+			if !strings.Contains(fileName, ".json") {
+				continue
 			}
 
-			return commentInfo, nil
+			if strings.Contains(fileName, summaryName) {
+				fullPath := filepath.Join(dirPath, fileName)
+				commentInfo, err := ioutil.ReadFile(fullPath)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to read code example file %s error: %s ", fullPath, err)
+				}
+
+				return commentInfo, nil
+			}
 		}
 	}
 

--- a/operation.go
+++ b/operation.go
@@ -25,7 +25,7 @@ type RouteProperties struct {
 }
 
 // Operation describes a single API operation on a path.
-// For more information: https://github.com/swaggo/swag#api-operation
+// For more information: https://github.com/piiano/swag#api-operation
 type Operation struct {
 	parser               *Parser
 	codeExampleFilesDirs []string

--- a/operation_test.go
+++ b/operation_test.go
@@ -2002,7 +2002,7 @@ func TestParseDescriptionMarkdown(t *testing.T) {
 	t.Parallel()
 
 	operation := NewOperation(nil)
-	operation.parser.markdownFileDir = "example/markdown"
+	operation.parser.markdownFileDirs = []string{"example/markdown"}
 
 	comment := `@description.markdown admin.md`
 
@@ -2191,7 +2191,7 @@ func TestParseCodeSamples(t *testing.T) {
 	const comment = `@x-codeSamples file`
 	t.Run("Find sample by file", func(t *testing.T) {
 
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "example"
 
 		err := operation.ParseComment(comment, nil)
@@ -2202,7 +2202,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run("With broken file sample", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "broken"
 
 		err := operation.ParseComment(comment, nil)
@@ -2210,7 +2210,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run("Example file not found", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "badExample"
 
 		err := operation.ParseComment(comment, nil)
@@ -2219,7 +2219,7 @@ func TestParseCodeSamples(t *testing.T) {
 
 	t.Run("Without line reminder", func(t *testing.T) {
 		comment := `@x-codeSamples`
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/code_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/code_examples"))
 		operation.Summary = "example"
 
 		err := operation.ParseComment(comment, nil)
@@ -2227,7 +2227,7 @@ func TestParseCodeSamples(t *testing.T) {
 	})
 
 	t.Run(" broken dir", func(t *testing.T) {
-		operation := NewOperation(nil, SetCodeExampleFilesDirectory("testdata/fake_examples"))
+		operation := NewOperation(nil, SetCodeExampleFilesDirectories("testdata/fake_examples"))
 		operation.Summary = "code"
 
 		err := operation.ParseComment(comment, nil)

--- a/packages_test.go
+++ b/packages_test.go
@@ -17,7 +17,7 @@ func TestPackagesDefinitions_CollectAstFile(t *testing.T) {
 		Name: &ast.Ident{Name: "main.go"},
 	}
 
-	packageDir := "github.com/swaggo/swag/testdata/simple"
+	packageDir := "github.com/piiano/swag/testdata/simple"
 	assert.NoError(t, pd.CollectAstFile(packageDir, "testdata/simple/"+firstFile.Name.String(), firstFile))
 	assert.NotEmpty(t, pd.packages[packageDir])
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -23,17 +23,17 @@ func TestNew(t *testing.T) {
 	t.Run("SetMarkdownFileDirectory", func(t *testing.T) {
 		t.Parallel()
 
-		expected := "docs/markdown"
-		p := New(SetMarkdownFileDirectory(expected))
-		assert.Equal(t, expected, p.markdownFileDir)
+		expected := []string{"docs/markdown"}
+		p := New(SetMarkdownFileDirectories(expected...))
+		assert.Equal(t, expected, p.markdownFileDirs)
 	})
 
 	t.Run("SetCodeExamplesDirectory", func(t *testing.T) {
 		t.Parallel()
 
-		expected := "docs/examples"
-		p := New(SetCodeExamplesDirectory(expected))
-		assert.Equal(t, expected, p.codeExampleFilesDir)
+		expected := []string{"docs/examples"}
+		p := New(SetCodeExamplesDirectories(expected...))
+		assert.Equal(t, expected, p.codeExampleFilesDirs)
 	})
 
 	t.Run("SetStrict", func(t *testing.T) {
@@ -358,7 +358,7 @@ func TestParser_ParseGeneralApiInfoWithOpsInSameFile(t *testing.T) {
 func TestParser_ParseGeneralAPIInfoMarkdown(t *testing.T) {
 	t.Parallel()
 
-	p := New(SetMarkdownFileDirectory("testdata"))
+	p := New(SetMarkdownFileDirectories("testdata"))
 	mainAPIFile := "testdata/markdown.go"
 	err := p.ParseGeneralAPIInfo(mainAPIFile)
 	assert.NoError(t, err)
@@ -2770,7 +2770,7 @@ func TestApiParseTag(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
@@ -2800,7 +2800,7 @@ func TestApiParseTag_NonExistendTag(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags_nonexistend_tag"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.Error(t, err)
@@ -2810,7 +2810,7 @@ func TestParseTagMarkdownDescription(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	if err != nil {
@@ -2831,7 +2831,7 @@ func TestParseApiMarkdownDescription(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/tags"
-	p := New(SetMarkdownFileDirectory(searchDir))
+	p := New(SetMarkdownFileDirectories(searchDir))
 	p.PropNamingStrategy = PascalCase
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -2049,9 +2049,9 @@ func TestParseTypeOverrides(t *testing.T) {
 
 	searchDir := "testdata/global_override"
 	p := New(SetOverrides(map[string]string{
-		"github.com/swaggo/swag/testdata/global_override/types.Application":  "string",
-		"github.com/swaggo/swag/testdata/global_override/types.Application2": "github.com/swaggo/swag/testdata/global_override/othertypes.Application",
-		"github.com/swaggo/swag/testdata/global_override/types.ShouldSkip":   "",
+		"github.com/piiano/swag/testdata/global_override/types.Application":  "string",
+		"github.com/piiano/swag/testdata/global_override/types.Application2": "github.com/piiano/swag/testdata/global_override/othertypes.Application",
+		"github.com/piiano/swag/testdata/global_override/types.ShouldSkip":   "",
 	}))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)

--- a/testdata/alias_import/api/api.go
+++ b/testdata/alias_import/api/api.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/alias_import/data"
-	"github.com/swaggo/swag/testdata/alias_type/types"
+	"github.com/piiano/swag/testdata/alias_import/data"
+	"github.com/piiano/swag/testdata/alias_type/types"
 )
 
 // @Summary Get application

--- a/testdata/alias_import/data/applicationresponse.go
+++ b/testdata/alias_import/data/applicationresponse.go
@@ -1,7 +1,7 @@
 package data
 
 import (
-	typesapplication "github.com/swaggo/swag/testdata/alias_import/types"
+	typesapplication "github.com/piiano/swag/testdata/alias_import/types"
 )
 
 type ApplicationResponse struct {

--- a/testdata/alias_import/main.go
+++ b/testdata/alias_import/main.go
@@ -3,7 +3,7 @@ package alias_import
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/alias_import/api"
+	"github.com/piiano/swag/testdata/alias_import/api"
 )
 
 // @title Swagger Example API

--- a/testdata/alias_type/api/api.go
+++ b/testdata/alias_type/api/api.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/swaggo/swag/testdata/alias_type/data"
+	"github.com/piiano/swag/testdata/alias_type/data"
 )
 
 /*// @Summary Get time as string

--- a/testdata/alias_type/data/alias.go
+++ b/testdata/alias_type/data/alias.go
@@ -1,8 +1,9 @@
 package data
 
 import (
-	"github.com/swaggo/swag/testdata/alias_type/types"
 	"time"
+
+	"github.com/piiano/swag/testdata/alias_type/types"
 )
 
 type TimeContainer struct {

--- a/testdata/alias_type/main.go
+++ b/testdata/alias_type/main.go
@@ -3,7 +3,7 @@ package alias_type
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/alias_type/api"
+	"github.com/piiano/swag/testdata/alias_type/api"
 )
 
 // @title Swagger Example API

--- a/testdata/code_examples/api/api1.go
+++ b/testdata/code_examples/api/api1.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	_ "github.com/swaggo/swag/testdata/conflict_name/model"
 	"net/http"
+
+	_ "github.com/piiano/swag/testdata/conflict_name/model"
 )
 
 // @Description  Check if Health  of service it's OK!

--- a/testdata/composition/api/api.go
+++ b/testdata/composition/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/composition/common"
+	"github.com/piiano/swag/testdata/composition/common"
 )
 
 type Foo struct {

--- a/testdata/composition/main.go
+++ b/testdata/composition/main.go
@@ -3,7 +3,7 @@ package composition
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/composition/api"
+	"github.com/piiano/swag/testdata/composition/api"
 )
 
 // @title Swagger Example API

--- a/testdata/conflict_name/api/api1.go
+++ b/testdata/conflict_name/api/api1.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	_ "github.com/swaggo/swag/testdata/conflict_name/model"
 	"net/http"
+
+	_ "github.com/piiano/swag/testdata/conflict_name/model"
 )
 
 // @Tags Health

--- a/testdata/conflict_name/api/api2.go
+++ b/testdata/conflict_name/api/api2.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	_ "github.com/swaggo/swag/testdata/conflict_name/model2"
 	"net/http"
+
+	_ "github.com/piiano/swag/testdata/conflict_name/model2"
 )
 
 // @Tags Health

--- a/testdata/conflict_name/expected.json
+++ b/testdata/conflict_name/expected.json
@@ -24,7 +24,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github.com_swaggo_swag_testdata_conflict_name_model.ErrorsResponse"
+                            "$ref": "#/definitions/github.com_piiano_swag_testdata_conflict_name_model.ErrorsResponse"
                         }
                     }
                 }
@@ -47,7 +47,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github.com_swaggo_swag_testdata_conflict_name_model2.ErrorsResponse"
+                            "$ref": "#/definitions/github.com_piiano_swag_testdata_conflict_name_model2.ErrorsResponse"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
         }
     },
     "definitions": {
-        "github.com_swaggo_swag_testdata_conflict_name_model.ErrorsResponse": {
+        "github.com_piiano_swag_testdata_conflict_name_model.ErrorsResponse": {
             "type": "object",
             "properties": {
                 "newTime": {
@@ -63,7 +63,7 @@
                 }
             }
         },
-        "github.com_swaggo_swag_testdata_conflict_name_model.MyStruct": {
+        "github.com_piiano_swag_testdata_conflict_name_model.MyStruct": {
             "type": "object",
             "properties": {
                 "name": {
@@ -71,7 +71,7 @@
                 }
             }
         },
-        "github.com_swaggo_swag_testdata_conflict_name_model2.ErrorsResponse": {
+        "github.com_piiano_swag_testdata_conflict_name_model2.ErrorsResponse": {
             "type": "object",
             "properties": {
                 "newTime": {
@@ -79,7 +79,7 @@
                 }
             }
         },
-        "github.com_swaggo_swag_testdata_conflict_name_model2.MyStruct": {
+        "github.com_piiano_swag_testdata_conflict_name_model2.MyStruct": {
             "type": "object",
             "properties": {
                 "name": {
@@ -91,7 +91,7 @@
             "type": "object",
             "properties": {
                 "my": {
-                    "$ref": "#/definitions/github.com_swaggo_swag_testdata_conflict_name_model.MyStruct"
+                    "$ref": "#/definitions/github.com_piiano_swag_testdata_conflict_name_model.MyStruct"
                 },
                 "name": {
                     "type": "string"
@@ -102,7 +102,7 @@
             "type": "object",
             "properties": {
                 "my": {
-                    "$ref": "#/definitions/github.com_swaggo_swag_testdata_conflict_name_model2.MyStruct"
+                    "$ref": "#/definitions/github.com_piiano_swag_testdata_conflict_name_model2.MyStruct"
                 },
                 "name": {
                     "type": "string"

--- a/testdata/duplicate_route/api/api.go
+++ b/testdata/duplicate_route/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	_ "github.com/swaggo/swag/testdata/simple/web"
+	_ "github.com/piiano/swag/testdata/simple/web"
 )
 
 // @Router /testapi/endpoint [get]

--- a/testdata/duplicate_route/main.go
+++ b/testdata/duplicate_route/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/duplicate_route/api"
+	"github.com/piiano/swag/testdata/duplicate_route/api"
 )
 
 func main() {

--- a/testdata/duplicated/main.go
+++ b/testdata/duplicated/main.go
@@ -3,7 +3,7 @@ package composition
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/duplicated/api"
+	"github.com/piiano/swag/testdata/duplicated/api"
 )
 
 // @title Swagger Example API

--- a/testdata/duplicated2/main.go
+++ b/testdata/duplicated2/main.go
@@ -3,7 +3,7 @@ package composition
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/duplicated2/api"
+	"github.com/piiano/swag/testdata/duplicated2/api"
 )
 
 // @title Swagger Example API

--- a/testdata/format_dst/api/api.go
+++ b/testdata/format_dst/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	_ "github.com/swaggo/swag/testdata/simple/web"
+	_ "github.com/piiano/swag/testdata/simple/web"
 )
 
 // @Summary      Add a new pet to the store

--- a/testdata/format_dst/main.go
+++ b/testdata/format_dst/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple/api"
+	"github.com/piiano/swag/testdata/simple/api"
 )
 
 // @title           Swagger Example API

--- a/testdata/format_dst/web/handler.go
+++ b/testdata/format_dst/web/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/shopspring/decimal"
 
-	"github.com/swaggo/swag/testdata/simple/cross"
+	"github.com/piiano/swag/testdata/simple/cross"
 )
 
 type Pet struct {

--- a/testdata/format_src/api/api.go
+++ b/testdata/format_src/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	_ "github.com/swaggo/swag/testdata/simple/web"
+	_ "github.com/piiano/swag/testdata/simple/web"
 )
 
 // @Summary Add a new pet to the store

--- a/testdata/format_src/main.go
+++ b/testdata/format_src/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple/api"
+	"github.com/piiano/swag/testdata/simple/api"
 )
 
 // @title Swagger Example API

--- a/testdata/format_src/web/handler.go
+++ b/testdata/format_src/web/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/shopspring/decimal"
 
-	"github.com/swaggo/swag/testdata/simple/cross"
+	"github.com/piiano/swag/testdata/simple/cross"
 )
 
 type Pet struct {

--- a/testdata/format_test/api/api.go
+++ b/testdata/format_test/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	_ "github.com/swaggo/swag/testdata/simple/web"
+	_ "github.com/piiano/swag/testdata/simple/web"
 )
 
 // @Summary Add a new pet to the store

--- a/testdata/format_test/main.go
+++ b/testdata/format_test/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple/api"
+	"github.com/piiano/swag/testdata/simple/api"
 )
 
 // @title Swagger Example API

--- a/testdata/format_test/web/handler.go
+++ b/testdata/format_test/web/handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/shopspring/decimal"
 
-	"github.com/swaggo/swag/testdata/simple/cross"
+	"github.com/piiano/swag/testdata/simple/cross"
 )
 
 type Pet struct {

--- a/testdata/global_override/api/api.go
+++ b/testdata/global_override/api/api.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/alias_type/types"
-	"github.com/swaggo/swag/testdata/global_override/data"
+	"github.com/piiano/swag/testdata/alias_type/types"
+	"github.com/piiano/swag/testdata/global_override/data"
 )
 
 // @Summary Get application

--- a/testdata/global_override/data/applicationresponse.go
+++ b/testdata/global_override/data/applicationresponse.go
@@ -1,7 +1,7 @@
 package data
 
 import (
-	typesapplication "github.com/swaggo/swag/testdata/global_override/types"
+	typesapplication "github.com/piiano/swag/testdata/global_override/types"
 )
 
 type ApplicationResponse struct {

--- a/testdata/global_override/main.go
+++ b/testdata/global_override/main.go
@@ -3,7 +3,7 @@ package global_override
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/global_override/api"
+	"github.com/piiano/swag/testdata/global_override/api"
 )
 
 // @title Swagger Example API

--- a/testdata/nested/api/api.go
+++ b/testdata/nested/api/api.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/nested2"
+	"github.com/piiano/swag/testdata/nested2"
 )
 
 type Foo struct {

--- a/testdata/nested/main.go
+++ b/testdata/nested/main.go
@@ -3,7 +3,7 @@ package composition
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/nested/api"
+	"github.com/piiano/swag/testdata/nested/api"
 )
 
 // @title Swagger Example API

--- a/testdata/pare_outside_dependencies/cmd/main.go
+++ b/testdata/pare_outside_dependencies/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/example/basic/api"
+	"github.com/piiano/swag/example/basic/api"
 )
 
 // @title Swagger Example API

--- a/testdata/quotes/main.go
+++ b/testdata/quotes/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/swaggo/swag"
-	"github.com/swaggo/swag/testdata/quotes/api"
-	_ "github.com/swaggo/swag/testdata/quotes/docs"
+	"github.com/piiano/swag"
+	"github.com/piiano/swag/testdata/quotes/api"
+	_ "github.com/piiano/swag/testdata/quotes/docs"
 )
 
 func ReadDoc() string {

--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	. "github.com/swaggo/swag/testdata/simple/cross"
-	_ "github.com/swaggo/swag/testdata/simple/web"
+	. "github.com/piiano/swag/testdata/simple/cross"
+	_ "github.com/piiano/swag/testdata/simple/web"
 )
 
 // @Summary Add a new pet to the store

--- a/testdata/simple/main.go
+++ b/testdata/simple/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple/api"
+	"github.com/piiano/swag/testdata/simple/api"
 )
 
 // @title Swagger Example API

--- a/testdata/simple/web/handler.go
+++ b/testdata/simple/web/handler.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/piiano/swag/testdata/simple/cross"
 	"github.com/shopspring/decimal"
-	"github.com/swaggo/swag/testdata/simple/cross"
 )
 
 type Pet struct {

--- a/testdata/simple2/main.go
+++ b/testdata/simple2/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple2/api"
+	"github.com/piiano/swag/testdata/simple2/api"
 )
 
 // @title Swagger Example API

--- a/testdata/simple3/main.go
+++ b/testdata/simple3/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple3/api"
+	"github.com/piiano/swag/testdata/simple3/api"
 )
 
 // @title Swagger Example API

--- a/testdata/simple_cgo/main.go
+++ b/testdata/simple_cgo/main.go
@@ -12,7 +12,7 @@ import "C"
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/simple_cgo/api"
+	"github.com/piiano/swag/testdata/simple_cgo/api"
 )
 
 // @title Swagger Example API

--- a/testdata/struct_comment/main.go
+++ b/testdata/struct_comment/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/swaggo/swag/testdata/struct_comment/api"
+	"github.com/piiano/swag/testdata/struct_comment/api"
 )
 
 // @title Swagger Example API


### PR DESCRIPTION
* You can call "--md" and "--cef" multiple times, and swag will look for the right files in all of the directories.
* Changed `swaggo/swag` to `piiano/swag` so we can easily use it